### PR TITLE
#167138269 Send email when question commented or answered

### DIFF
--- a/answers/tests/models.py
+++ b/answers/tests/models.py
@@ -2,15 +2,19 @@ from django.test import TestCase
 from accounts.models import User
 
 
-class TestUserModel(TestCase):
+class TestQuestionModel(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create(
+            email="faga@gh.com",
+            username="username",
+            display_name="username",
+            password="Philo1234")
 
     def test_title(self):
         user = User.objects.create(
             email="faga@gh.com",
             username="username",
             display_name="username",
-            bio="bio",
-            is_active=True,
             password="Philo1234")
         self.assertEquals(user.email, "faga@gh.com")
-        self.assertEquals(user.bio, "bio")

--- a/stackoverflow/settings.py
+++ b/stackoverflow/settings.py
@@ -141,3 +141,10 @@ NOSE_ARGS = [
     '--with-coverage',
 ]
 LOGIN_REDIRECT_URL = 'questions:question_list'
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_PORT = config('EMAIL_PORT')
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = config('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD')


### PR DESCRIPTION
 **What does this PR do?**
This PR ensures that a user can receive Email notifications for questions when his/her question has answered or commented on.

**Description of Task to be completed?**
- Add the send_email method in AnswerView Post

**What are the relevant Pivotal Tracker stories?**
[#167138269](https://www.pivotaltracker.com/n/projects/2364284/stories/167138269)

**How should be tested manually?**
Run each of the following commands in your terminal in the respective order.

- `git clone https://github.com/fahadmak/stackoverflow_clone.git`
- `cd stackoverflow_clone`
- `git checkout ft-create-list-question-comments-167138181`
- `virtualenv venv`
- `. venv/bin/activate`
- `pip install -r requirements.txt`
- `run migrations using this command python manage.py migrate`
- `run python manage.py runserver 127.0.0.1:8000`
- `Go to this link in your browser 127.0.0.1:8000`
- `You will be redirected to the login page where you should log in`
- `Click on the 'Register Today' link to go to sign up page`
- `Try to sign up an account and then use it in the login page`
- Create a question
- `Click on the question you created to go to the question_detail page`
- `Click on comment or answer button in the answer card to open comment form`
- `Write a comment/answer in the form`
- Check your inbox for an email from the app 

**Screenshots**
<img width="1021" alt="Screen Shot 2019-07-21 at 5 27 02 PM" src="https://user-images.githubusercontent.com/13882936/61592500-ca7f3580-abdc-11e9-8f1e-aa4eef94a072.png">

[Delivers #167138269]