### PR TITLE
feature(Email): Send email when answer is commented on

### DIFF
--- a/accounts/tests/test_models.py
+++ b/accounts/tests/test_models.py
@@ -14,3 +14,24 @@ class TestUserModel(TestCase):
             password="Philo1234")
         self.assertEquals(user.email, "faga@gh.com")
         self.assertEquals(user.bio, "bio")
+
+    def test_super_user_created(self):
+        user = User.objects.create_superuser(
+            email="faga@gh.com",
+            username="username",
+            display_name="username",
+            password="Philo1234")
+
+        self.assertEquals(user.display_name, "username")
+
+    def test__user_created(self):
+        user = User.objects.create_user(
+            email="faga@gh.com",
+            username="username",
+            display_name="username",
+            password="Philo1234")
+
+        self.assertEquals(user.display_name, "username")
+        self.assertEquals(user.get_short_name(), "username")
+        self.assertEquals(user.get_long_name(), "username @(username)")
+        self.assertEquals(str(user), "@username")

--- a/answers/views.py
+++ b/answers/views.py
@@ -64,5 +64,9 @@ class AnswerView(LoginRequiredMixin, TemplateView):
             new_comment.author = self.request.user
             new_comment.answer = Answer.objects.get(id=kwargs['answer_id'])
             new_comment.save()
+            send_mail('Your answer has been commented on',
+                      f"Your answer \'{new_comment.answer.title}\' has received a comment. Click  to see {domain}",
+                      settings.EMAIL_HOST_USER,
+                      [context['question'].author.email])
             return HttpResponseRedirect(reverse('answers:answer_list', kwargs={'question_id': kwargs['question_id']}))
         return self.render_to_response({'aform': answer_form})


### PR DESCRIPTION
 **What does this PR do?**
This PR ensures that a user can receive Email notifications for questions when his/her question has answered or commented on.

**Description of Task to be completed?**
- Add another send_email method in AnswerView Post method

**What are the relevant Pivotal Tracker stories?**
[#167138288](https://www.pivotaltracker.com/n/projects/2364284/stories/167138288)

**How should be tested manually?**
Run each of the following commands in your terminal in the respective order.

- `git clone https://github.com/fahadmak/stackoverflow_clone.git`
- `cd stackoverflow_clone`
- `git checkout ft-create-list-question-comments-167138181`
- `virtualenv venv`
- `. venv/bin/activate`
- `pip install -r requirements.txt`
- `run migrations using this command python manage.py migrate`
- `run python manage.py runserver 127.0.0.1:8000`
- `Go to this link in your browser 127.0.0.1:8000`
- `You will be redirected to the login page where you should log in`
- `Click on the 'Register Today' link to go to sign up page`
- `Try to sign up an account and then use it in the login page`
- Create a question
- `Click on the question you created to go to the question_detail page`
- `Go to the answer you would like to comment on `
- `Write a comment in the form`
- Check your inbox for an email from the app 

**Screenshots**
<img width="1021" alt="Screen Shot 2019-07-21 at 5 27 02 PM" src="https://user-images.githubusercontent.com/13882936/61592500-ca7f3580-abdc-11e9-8f1e-aa4eef94a072.png">
